### PR TITLE
implement sd_notify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,28 @@ as follows:
       provides the API to sysadmin
     - [yaml-cpp](https://github.com/jbeder/yaml-cpp) provides YAML config file support
 
+Systemd Integration
+===================
+
+sysadmin can integrate with systemd as a `notify` type service which can
+prevent races between other services that rely on sysadmin for configuration.
+In order to build sysadmin with systemd notify support you need to pass
+`-DSYSADMIN_USE_SD_NOTIFY` during step 3 outlined below. When building sysadmin
+in this configuration `libsystemd` becomes a required dependency.
+
+There is an a systemd service definition which incorporates this functionality
+located [here](configs/prod/systemd-notify.service).
+
 Development
 ===========
 
 Generally speaking, build as follows:
 
-```
-mkdir build
-cd build
-cmake ..
-make check
-make
-```
+1. mkdir build
+2. cd build
+3. cmake ..
+4. make check
+5. make
 
 `make check` runs only sysadmin's tests. If you wish to run the decibel-cpp tests, run
 `make decibel-check`.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In order to build sysadmin with systemd notify support you need to pass
 in this configuration `libsystemd` becomes a required dependency.
 
 There is an a systemd service definition which incorporates this functionality
-located [here](configs/prod/systemd-notify.service).
+located [here](configs/prod/sysadmin-notify.service).
 
 Development
 ===========

--- a/cmake/FindSystemd.cmake
+++ b/cmake/FindSystemd.cmake
@@ -1,0 +1,40 @@
+#.rst:
+# FindSystemd
+# -------
+#
+# Find Systemd library
+#
+# Try to find Systemd library on UNIX systems. The following values are defined
+#
+# ::
+#
+#   SYSTEMD_FOUND         - True if Systemd is available
+#   SYSTEMD_INCLUDE_DIRS  - Include directories for Systemd
+#   SYSTEMD_LIBRARIES     - List of libraries for Systemd
+#   SYSTEMD_DEFINITIONS   - List of definitions for Systemd
+#
+#=============================================================================
+# Copyright (c) 2015 Jari Vetoniemi
+#
+# Distributed under the OSI-approved BSD License (the "License");
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+
+include(FeatureSummary)
+set_package_properties(Systemd PROPERTIES
+   URL "http://freedesktop.org/wiki/Software/systemd/"
+   DESCRIPTION "System and Service Manager")
+
+find_package(PkgConfig)
+pkg_check_modules(PC_SYSTEMD QUIET libsystemd)
+find_library(SYSTEMD_LIBRARIES NAMES systemd ${PC_SYSTEMD_LIBRARY_DIRS})
+find_path(SYSTEMD_INCLUDE_DIRS systemd/sd-login.h HINTS ${PC_SYSTEMD_INCLUDE_DIRS})
+
+set(SYSTEMD_DEFINITIONS ${PC_SYSTEMD_CFLAGS_OTHER})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SYSTEMD DEFAULT_MSG SYSTEMD_INCLUDE_DIRS SYSTEMD_LIBRARIES)
+mark_as_advanced(SYSTEMD_INCLUDE_DIRS SYSTEMD_LIBRARIES SYSTEMD_DEFINITIONS)

--- a/configs/prod/sysadmin-notify.service
+++ b/configs/prod/sysadmin-notify.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sysadmin
+After=network.target syslog.target
+
+[Service]
+Type=notify
+ExecStart=/bin/sysadmin /etc/sysadmin/config.yaml
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/decibel-cpp/include/decibel/messaging/Reactor.h
+++ b/decibel-cpp/include/decibel/messaging/Reactor.h
@@ -70,9 +70,7 @@ public:
         return pPromise->getFuture();
     }
 
-    // This is kept around for posterity should anyone want to add back
-    // folly::Executor functionality
-    // virtual void add(folly::Func fn);
+    virtual void add(folly::Func fn);
 
     // folly::TimeKeeper
     virtual folly::Future<folly::Unit> after(folly::Duration duration);

--- a/decibel-cpp/include/decibel/messaging/Reactor.h
+++ b/decibel-cpp/include/decibel/messaging/Reactor.h
@@ -70,7 +70,9 @@ public:
         return pPromise->getFuture();
     }
 
-    virtual void add(folly::Func fn);
+    // This doesn't compile on OS X, but, leave it here for posterity's sake.
+    // You can uncomment this to turn this class into a folly::Executor.
+    // virtual void add(folly::Func fn);
 
     // folly::TimeKeeper
     virtual folly::Future<folly::Unit> after(folly::Duration duration);

--- a/decibel-cpp/src/decibel/messaging/Reactor.cpp
+++ b/decibel-cpp/src/decibel/messaging/Reactor.cpp
@@ -152,10 +152,12 @@ void Reactor::CancelCall(std::shared_ptr<OneShotTimerEvent> pTimer)
     pTimer->Stop();
 }
 
-void Reactor::add(folly::Func fn)
-{
-    CallSoon(fn);
-}
+// see include/decibel/messaging/Reactor.h for the reason behind this being
+// commented out.
+// void Reactor::add(folly::Func fn)
+// {
+//     CallSoon(fn);
+// }
 
 folly::Future<folly::Unit> Reactor::after(folly::Duration duration)
 {

--- a/decibel-cpp/src/decibel/messaging/Reactor.cpp
+++ b/decibel-cpp/src/decibel/messaging/Reactor.cpp
@@ -152,12 +152,10 @@ void Reactor::CancelCall(std::shared_ptr<OneShotTimerEvent> pTimer)
     pTimer->Stop();
 }
 
-// This is kept around for posterity should anyone want to add back
-// folly::Executor functionality
-// void Reactor::add(folly::Func fn)
-// {
-//     CallSoon(fn);
-// }
+void Reactor::add(folly::Func fn)
+{
+    CallSoon(fn);
+}
 
 folly::Future<folly::Unit> Reactor::after(folly::Duration duration)
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,5 +72,15 @@ target_link_libraries(libsysadmin INTERFACE ${LIBS} decibel)
 target_include_directories(libsysadmin PUBLIC ${CMAKE_BINARY_DIR} ${PROJECT_SOURCE_DIR})
 target_link_libraries(sysadmin libsysadmin)
 
+if(SYSADMIN_USE_SD_NOTIFY)
+    include(FindSystemd)
+    find_package(Systemd REQUIRED)
+
+    target_link_libraries(sysadmin ${SYSTEMD_LIBRARIES})
+    target_include_directories(sysadmin PRIVATE ${SYSTEMD_INCLUDE_DIRS})
+
+    target_compile_definitions(sysadmin PRIVATE _SYSADMIN_USE_SD_NOTIFY)
+endif()
+
 install(TARGETS sysadmin
         RUNTIME DESTINATION bin)

--- a/src/sysadmin.cpp
+++ b/src/sysadmin.cpp
@@ -109,7 +109,7 @@ int main(int argc, const char* argv[])
         });
 
 #ifdef _SYSADMIN_USE_SD_NOTIFY
-    reactor.add([]() {
+    reactor.CallSoon([]() {
         auto rc = sd_notify(1, "READY=1");
 
         if (rc < 0) {


### PR DESCRIPTION
We've hit a condition in house where other services that depend on Sysadmin race against Sysadmin starting up. Using `sd_notify` inside the the event loop should prevent this from occurring.