### PR TITLE
-z checks for zero length string, exit on error

### DIFF
--- a/docker_builds/image_deploy.sh
+++ b/docker_builds/image_deploy.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set +x
+set -e
 
 TAG=$1
 DOCKER_USERNAME=$2
 DOCKER_PASSWORD=$3
 
-if [ ! -z "${DOCKER_PASSWORD+x}" ]; then
+if [ -z "${DOCKER_PASSWORD}" ]; then
     echo "Not enough args"
     exit 1
 fi


### PR DESCRIPTION
The docker push failed on the commit to master because I used the `-z` flag incorrectly. 
https://travis-ci.org/StarryInternet/sysadmin/builds/302682647#L1003

This fixes that and will also stop the script sooner if it fails.