### PR TITLE
avoid CLI option that may not be available 

### DIFF
--- a/docker_builds/image_deploy.sh
+++ b/docker_builds/image_deploy.sh
@@ -14,5 +14,6 @@ fi
 # retag the image we made earlier
 docker image tag starryoss/sysadmin-build:latest "starryoss/sysadmin-build:${TAG}"
 
-echo "$DOCKER_PASSWORD" | docker login --password-stdin -u="$DOCKER_USERNAME"
+docker login --password="$DOCKER_PASSWORD" --username="$DOCKER_USERNAME"
+
 docker push "starryoss/sysadmin-build:${TAG}"


### PR DESCRIPTION
The last push failed, I am guessing, because the version of docker doesn't have the `--password-stdin`  option. 
The failure message is here https://travis-ci.org/StarryInternet/sysadmin/builds/302709178#L1003