### PR TITLE
release v1

### DIFF
--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -5,7 +5,7 @@ name = "sysadmin-bindings"
 # we don't want to go to 1.0 until we have the api finalized
 # http://doc.crates.io/manifest.html#the-version-field
 # https://github.com/StarryInternet/sysadmin
-version = "0.0.7"
+version = "1.0.0"
 authors = ["Starry Inc <oss@starry.com>"]
 include = [
     "build.rs",


### PR DESCRIPTION
I pushed a pre-release version of these changes to cargo and what is in cargo no longer reflects what was eventually merged in this PR.  https://github.com/StarryInternet/sysadmin/pull/28 

We should push a version 1 of the bindings  based on the final commit.