### PR TITLE
Fix import * functionality

### DIFF
--- a/clients/python/sysadmin/__init__.py
+++ b/clients/python/sysadmin/__init__.py
@@ -7,10 +7,10 @@ from SysAdminUser import FetchAllValues
 
 
 __all__ = [
-    ConfigTemplateRenderer,
-    SysAdminClient,
-    FetchAllValues,
-    UnpackFromProto,
-    SysAdminMigrator,
-    LazySysAdmin,
+    'ConfigTemplateRenderer',
+    'SysAdminClient',
+    'FetchAllValues',
+    'UnpackFromProto',
+    'SysAdminMigrator',
+    'LazySysAdmin',
 ]


### PR DESCRIPTION
The underlying `__import__()` function that the `import` keyword calls
expects a list of strings as its `fromlist` argument, and will throw
a TypeError otherwise.

change this:
```
>>> from sysadmin import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Item in ``from list'' must be str, not classobj
>>> 
```
to this:
```
>>> from sysadmin import *
>>> ConfigTemplateRenderer
<class sysadmin.ConfigTemplateRenderer.ConfigTemplateRenderer at 0x7fee14726738>
>>> 
```