### PR TITLE
Fix indent on multi-line exception

### DIFF
--- a/clients/python/sysadmin/Migrations.py
+++ b/clients/python/sysadmin/Migrations.py
@@ -22,7 +22,7 @@ def load_migrations(path):
             migrations.append((path, yaml.load(f)))
     else:
         raise ValueError('Given migrations path (%s) is neither a directory '
-￼                 'or a file. Skipping migrations' % path)
+                            'or a file. Skipping migrations' % path)
     return migrations
 
 


### PR DESCRIPTION
Python wasn't happy with the indent on the second line of the Migrations exception message.
Also added a try/except on the only other use of `load_migrations`