### PR TITLE
require C++11 for protobuf 3.6.x support

### DIFF
--- a/sysadmin-api/CMakeLists.txt
+++ b/sysadmin-api/CMakeLists.txt
@@ -13,6 +13,7 @@ protobuf_generate_python(PROTO_PYS ${PROTO_FILES})
 
 # "link" python files so they get generated (they don't actually get linked)
 add_library(sysadmin-api STATIC ${PROTO_SRCS} ${PROTO_PYS})
+set_property(TARGET sysadmin-api PROPERTY CXX_STANDARD 11)
 target_link_libraries(sysadmin-api INTERFACE ${PROTOBUF_LIBRARIES})
 target_include_directories(sysadmin-api INTERFACE ${CMAKE_BINARY_DIR})
 link_directories(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Protobuf 3.6.x requires C++11 support.