### PR TITLE
Add python 3.6 and 3.7 support

### DIFF
--- a/clients/python/.gitignore
+++ b/clients/python/.gitignore
@@ -3,3 +3,4 @@
 dist/
 
 generated/
+.tox/

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -73,6 +73,7 @@ setup(
         'protobuf>=3.0,<4.0',
         'pytz>=2016.1',
         'PyYAML>=3.11,<4.0',
+        'six>=1.9,<2.0',
     ],
     extras_require={
         'test': [
@@ -95,7 +96,8 @@ setup(
     ],
     classifiers=[
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7'
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/clients/python/sysadmin/Migrations.py
+++ b/clients/python/sysadmin/Migrations.py
@@ -4,6 +4,7 @@ import glob
 import hashlib
 import os
 
+import six
 import yaml
 from sysadmin import SysAdminClient
 from sysadmin import UnpackFromProto
@@ -57,7 +58,7 @@ class MigrationLog(object):
 
 def nested_setter(sysadmin, config, op):
     def inner_set_configs(current, key_prefix):
-        for k, v in current.iteritems():
+        for k, v in six.iteritems(current):
             key = k if key_prefix == '' else '.'.join([key_prefix, k])
             if isinstance(v, dict):
                 inner_set_configs(v, key)
@@ -93,7 +94,7 @@ class SysAdminMigrator(object):
 
     def rename_keys(self, keys):
         for key in keys:
-            oldkey = key.keys()[0]
+            oldkey = list(key.keys())[0]
             newkey = key[oldkey]
             rename_key(self.sysadmin, oldkey, newkey)
 

--- a/clients/python/sysadmin/SysAdminUser.py
+++ b/clients/python/sysadmin/SysAdminUser.py
@@ -1,3 +1,4 @@
+import six
 from sysadmin import SysAdminClient
 from sysadmin import UnpackFromProto
 from sysadmin.generated import sysadminctl_pb2
@@ -39,7 +40,7 @@ def condense(uncondensed):
                 partialDict[keys[0]] = {}
             innerCondense(partialDict[keys[0]], keys[1:], value)
     output = {}
-    for key, value in uncondensed.iteritems():
+    for key, value in six.iteritems(uncondensed):
         keyparts = key.split(".")
         innerCondense(output, keyparts, value)
     return output

--- a/clients/python/sysadmin/__init__.py
+++ b/clients/python/sysadmin/__init__.py
@@ -1,9 +1,9 @@
-from Client import SysAdminClient
-from Client import UnpackFromProto
-from ConfigTemplateRenderer import ConfigTemplateRenderer
-from LazySysAdmin import LazySysAdmin
-from Migrations import SysAdminMigrator
-from SysAdminUser import FetchAllValues
+from sysadmin.Client import SysAdminClient
+from sysadmin.Client import UnpackFromProto
+from sysadmin.ConfigTemplateRenderer import ConfigTemplateRenderer
+from sysadmin.LazySysAdmin import LazySysAdmin
+from sysadmin.Migrations import SysAdminMigrator
+from sysadmin.SysAdminUser import FetchAllValues
 
 
 __all__ = [

--- a/clients/python/sysadminctl
+++ b/clients/python/sysadminctl
@@ -6,6 +6,7 @@ import inspect
 import random
 import socket
 import sys
+import six
 from sysadmin import SysAdminClient
 from sysadmin import UnpackFromProto
 from sysadmin.generated import sysadminctl_pb2
@@ -364,7 +365,7 @@ def _get_commands_map():
 
 
 def initialize_subcommands(commands, argparser):
-    for (name, command) in commands.iteritems():
+    for (name, command) in six.iteritems(commands):
         inited = command(argparser)
         commands[name] = inited
 
@@ -379,6 +380,7 @@ def main():
     parser.add_argument("--xid", type=int, default=0,
                         help="Transaction xid")
     subparser = parser.add_subparsers(dest="command")
+    subparser.required = True
     command_map = _get_commands_map()
     initialize_subcommands(command_map, subparser)
     args = parser.parse_args()

--- a/clients/python/tests/sys_test.py
+++ b/clients/python/tests/sys_test.py
@@ -299,8 +299,8 @@ class GetAllKeysTest(SysAdminFixture):
         self.assertEqual(set(["network.dhcp.startip", "network.dhcp.endip",
                               "network.dhcp.interfaces"]),
                          resp)
-        resp = map(lambda x: UnpackFromProto(x.value),
-                   client.get("network.dhcp.*").get.kvs)
+        resp = list(map(lambda x: UnpackFromProto(x.value),
+                        client.get("network.dhcp.*").get.kvs))
         self.assertEqual(3, len(resp))
         self.assertTrue("192.168.1.1" in resp)
         self.assertTrue("192.168.1.100" in resp)
@@ -310,8 +310,8 @@ class GetAllKeysTest(SysAdminFixture):
                               "network.dhcp.interfaces", "network.breakfast",
                               "network.lease"]),
                          resp)
-        resp = map(lambda x: UnpackFromProto(x.value),
-                   client.get("network.*").get.kvs)
+        resp = list(map(lambda x: UnpackFromProto(x.value),
+                        client.get("network.*").get.kvs))
         self.assertEqual(5, len(resp))
         self.assertTrue("192.168.1.1" in resp)
         self.assertTrue("192.168.1.100" in resp)

--- a/clients/python/tox.ini
+++ b/clients/python/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27, py36, py37
+
+[testenv]
+description = Run the unit tests with nose under {basepython}
+deps =
+    nose
+
+commands =
+    nosetests


### PR DESCRIPTION
The unit tests were failing before the changes (1 error, 6 failures). This patch didn't change those results -- the same tests still pass and fail the same way. I used tox for ease of ensuring compatibility, but I can take out the configuration file if you don't want it in the project.

* Make relative imports absolute.
* Only use unicode type in python 2, since it does not exist in
  python 3.
* Use bytes instead of string in python 3 to prevent TypeErrors during
  concatenation.
* Use six.iteritems where necessary.
* Cast certain function calls to lists, as they return iterators in
  python 3 and cannot be indexed.
* Set subparser.required to True, as default changed to False in 3.5+.
* Add a tox configuration for automatic compatibility testing.
* While there's no additions that obviously break Python 2.6
  compatibility, virtualenv, pip, etc. aren't compatible with 2.6 so
  it's hard to test.