### PR TITLE
PSST-1971: Fix migration check_history bug

### DIFF
--- a/clients/python/sysadmin/Migrations.py
+++ b/clients/python/sysadmin/Migrations.py
@@ -28,7 +28,7 @@ def load_migrations(path):
 
 
 def hash_migration(migration):
-    return hashlib.md5(yaml.dump(migration)).hexdigest()
+    return hashlib.md5(yaml.dump(migration, default_flow_style=None)).hexdigest()
 
 
 class MigrationLog(object):
@@ -53,7 +53,7 @@ class MigrationLog(object):
 
     def save(self, path):
         with open(path, "w") as f:
-            f.write(yaml.dump(self.migrations))
+            f.write(yaml.dump(self.migrations, default_flow_style=None))
 
 
 def nested_setter(sysadmin, config, op):


### PR DESCRIPTION
`yaml.dump()` default format changed. Set default_flow_style to maintain
consistent migration log hashes.

Bug introduced in d637e958b30197094754afddba65f47ab6470a5b
Setting `default_flow_style=None` maintains the same behavior from before py-yaml version bump