### PR TITLE
Change to start after network-pre.target

### DIFF
--- a/configs/prod/sysadmin.service
+++ b/configs/prod/sysadmin.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Sysadmin
-After=network.target syslog.target
+After=network-pre.target syslog.target
 
 [Service]
 ExecStart=/bin/sysadmin /etc/sysadmin/config.yaml


### PR DESCRIPTION
Some other services might depend on sysadmin but before systemd-networkd.  But network.target depends on systemd-networkd.  Since sysadmin binds to INADDR_ANY:4000, it does not have to wait for network.target.